### PR TITLE
build: fix semantic-release version variable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ universal = true
 [tool.semantic_release]
 commit_message = "chore(release): preparing {version}"
 version_variables = [
-    "drydock/__about__.py:__version__",
+    "tutorsentry.__about__.__version__",
 ]
 
 [tool.semantic_release.branches.main]


### PR DESCRIPTION
# Description

This was a error in the semantic release configuration that failed the release workflow.