### PR TITLE
build: fix an additional error in the release setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ local-release:
 	@echo "You can push the changes and release manually."
 	semantic-release version --changelog --commit --no-push
 
+dryrun-release:
+	@echo "New release dryrun"
+	semantic-release --noop version  --changelog --commit --push --tag
+
 ESCAPE = 
 help: ## Print this help
 	@grep -E '^([a-zA-Z_-]+:.*?## .*|######* .+)$$' Makefile \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ universal = true
 [tool.semantic_release]
 commit_message = "chore(release): preparing {version}"
 version_variables = [
-    "tutorsentry.__about__.__version__",
+    "tutorsentry/__about__.py:__version__",
 ]
 
 [tool.semantic_release.branches.main]


### PR DESCRIPTION
Also include a `dryrun-release` make target to test basic release configurations.